### PR TITLE
Add DB Docker script and properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
-
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.url=jdbc:mysql://127.0.0.1:3306/evc_dev
+spring.datasource.username=root
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=create

--- a/src/main/scripts/db-init.sh
+++ b/src/main/scripts/db-init.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_DATABASE=evc_dev -d mysql:8.0.24


### PR DESCRIPTION
* MySQL dependency 추가
* Docker script 추가
* db properties 추가

### 로컬에서 DB 셋팅 방법
```
우선 요구 조건: docker 설치

$ cd src/main/scripts
$ sh db-init.sh                 
6cb8bbe6ac5c4f0af07ceb64f5afb09e890a072af8c7d924d1f9b1c32a33aeb7

$ docker ps
CONTAINER ID   IMAGE          COMMAND                  CREATED         STATUS         PORTS                               NAMES
6cb8bbe6ac5c   mysql:8.0.24   "docker-entrypoint.s…"   4 seconds ago   Up 2 seconds   0.0.0.0:3306->3306/tcp, 33060/tcp   vigorous_tharp
```
Docker 로 MySQL 을 띄우고 application 실행하면 테이블 자동 생성됨.

<img width="395" alt="스크린샷 2021-05-02 오후 6 50 06" src="https://user-images.githubusercontent.com/19898854/116809344-832b2480-ab78-11eb-9c78-9f583d30e4f5.png">
